### PR TITLE
Refactor asciiviz into modular sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile — builds asciiviz and bakes presets + palettes
 APP       := asciiviz
-SRC       := asciiviz.c
+SRC       := main.c util.c terminal.c
 PRESETS_H := baked_presets.h
 PALETTES_H:= baked_palettes.h
 

--- a/main.c
+++ b/main.c
@@ -9,63 +9,18 @@
 #include <math.h>
 #include <time.h>
 #include <unistd.h>
-#include <termios.h>
-#include <sys/ioctl.h>
 #include <signal.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <ctype.h>
+#include "util.h"
+#include "terminal.h"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
 
-// ----------------------------- tiny utils ----------------------------------
-static long clamp_long(long v,long lo,long hi){ if(v<lo) return lo; if(v>hi) return hi; return v; }
-static double clamp(double v,double lo,double hi){ if(v<lo) return lo; if(v>hi) return v>hi?hi:v; return v; }
-static double now_sec(void){ struct timespec ts; clock_gettime(CLOCK_MONOTONIC,&ts); return ts.tv_sec + ts.tv_nsec/1e9; }
-static void msleep(int ms){ struct timespec ts={ms/1000,(ms%1000)*1000000L}; nanosleep(&ts,NULL); }
-
-// ----------------------------- terminal raw --------------------------------
-static struct termios g_old;
-static int g_raw = 0;
-static void term_raw_on(void){
-    if(g_raw) return;
-    struct termios t;
-    tcgetattr(STDIN_FILENO,&g_old);
-    t = g_old;
-    t.c_lflag &= ~(ICANON|ECHO);
-    t.c_cc[VMIN] = 0; t.c_cc[VTIME]=0;
-    tcsetattr(STDIN_FILENO,TCSANOW,&t);
-    g_raw=1;
-}
-static void term_raw_off(void){
-    if(!g_raw) return;
-    tcsetattr(STDIN_FILENO,TCSANOW,&g_old);
-    g_raw=0;
-}
-static void term_hide_cursor(void){ write(STDOUT_FILENO,"\x1b[?25l",6); }
-static void term_show_cursor(void){ write(STDOUT_FILENO,"\x1b[?25h",6); }
-static void term_clear(void){ write(STDOUT_FILENO,"\x1b[2J\x1b[H",7); }
-static void term_move(int row,int col){
-    char esc[32];
-    int n=snprintf(esc,sizeof(esc),"\x1b[%d;%dH", row, col);
-    write(STDOUT_FILENO,esc,n);
-}
-static void term_clear_line(void){ write(STDOUT_FILENO,"\x1b[2K",4); }
-static void term_alt_on(void){ write(STDOUT_FILENO, "\x1b[?1049h", 8); }
-static void term_alt_off(void){ write(STDOUT_FILENO, "\x1b[?1049l", 8); }
-static void term_wrap_off(void){ write(STDOUT_FILENO, "\x1b[?7l", 5); }
-static void term_wrap_on(void){ write(STDOUT_FILENO, "\x1b[?7h", 5); }
-
-// ----------------------------- window size ---------------------------------
-static volatile sig_atomic_t g_resized = 0;
-static void on_winch(int sig){ (void)sig; g_resized=1; }
-static void get_tty_size(int *w,int *h){
-    struct winsize ws;
-    if(ioctl(STDOUT_FILENO,TIOCGWINSZ,&ws)==0 && ws.ws_col>0 && ws.ws_row>0){ *w=ws.ws_col; *h=ws.ws_row; return; }
-    *w=80; *h=24;
-}
+// utility and terminal helpers moved to util.c and terminal.c
 
 // ----------------------------- config --------------------------------------
 typedef enum { MODE_EXPR=0, MODE_MANDELBROT=1, MODE_JULIA=2 } ModeType;

--- a/terminal.c
+++ b/terminal.c
@@ -1,0 +1,47 @@
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+#include "terminal.h"
+#include <termios.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+
+static struct termios g_old;
+static int g_raw = 0;
+volatile sig_atomic_t g_resized = 0;
+
+void term_raw_on(void){
+    if(g_raw) return;
+    struct termios t;
+    tcgetattr(STDIN_FILENO,&g_old);
+    t = g_old;
+    t.c_lflag &= ~(ICANON|ECHO);
+    t.c_cc[VMIN] = 0; t.c_cc[VTIME]=0;
+    tcsetattr(STDIN_FILENO,TCSANOW,&t);
+    g_raw=1;
+}
+void term_raw_off(void){
+    if(!g_raw) return;
+    tcsetattr(STDIN_FILENO,TCSANOW,&g_old);
+    g_raw=0;
+}
+void term_hide_cursor(void){ write(STDOUT_FILENO,"\x1b[?25l",6); }
+void term_show_cursor(void){ write(STDOUT_FILENO,"\x1b[?25h",6); }
+void term_clear(void){ write(STDOUT_FILENO,"\x1b[2J\x1b[H",7); }
+void term_move(int row,int col){
+    char esc[32];
+    int n=snprintf(esc,sizeof(esc),"\x1b[%d;%dH", row, col);
+    write(STDOUT_FILENO,esc,n);
+}
+void term_clear_line(void){ write(STDOUT_FILENO,"\x1b[2K",4); }
+void term_alt_on(void){ write(STDOUT_FILENO, "\x1b[?1049h", 8); }
+void term_alt_off(void){ write(STDOUT_FILENO, "\x1b[?1049l", 8); }
+void term_wrap_off(void){ write(STDOUT_FILENO, "\x1b[?7l", 5); }
+void term_wrap_on(void){ write(STDOUT_FILENO, "\x1b[?7h", 5); }
+
+void on_winch(int sig){ (void)sig; g_resized=1; }
+void get_tty_size(int *w,int *h){
+    struct winsize ws;
+    if(ioctl(STDOUT_FILENO,TIOCGWINSZ,&ws)==0 && ws.ws_col>0 && ws.ws_row>0){ *w=ws.ws_col; *h=ws.ws_row; return; }
+    *w=80; *h=24;
+}

--- a/terminal.h
+++ b/terminal.h
@@ -1,0 +1,18 @@
+#ifndef TERMINAL_H
+#define TERMINAL_H
+#include <signal.h>
+void term_raw_on(void);
+void term_raw_off(void);
+void term_hide_cursor(void);
+void term_show_cursor(void);
+void term_clear(void);
+void term_move(int row,int col);
+void term_clear_line(void);
+void term_alt_on(void);
+void term_alt_off(void);
+void term_wrap_off(void);
+void term_wrap_on(void);
+void on_winch(int sig);
+void get_tty_size(int *w,int *h);
+extern volatile sig_atomic_t g_resized;
+#endif

--- a/util.c
+++ b/util.c
@@ -1,0 +1,9 @@
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
+#include "util.h"
+#include <time.h>
+
+long clamp_long(long v,long lo,long hi){ if(v<lo) return lo; if(v>hi) return hi; return v; }
+double clamp(double v,double lo,double hi){ if(v<lo) return lo; if(v>hi) return v>hi?hi:v; return v; }
+double now_sec(void){ struct timespec ts; clock_gettime(CLOCK_MONOTONIC,&ts); return ts.tv_sec + ts.tv_nsec/1e9; }
+void msleep(int ms){ struct timespec ts={ms/1000,(ms%1000)*1000000L}; nanosleep(&ts,NULL); }

--- a/util.h
+++ b/util.h
@@ -1,0 +1,7 @@
+#ifndef UTIL_H
+#define UTIL_H
+long clamp_long(long v,long lo,long hi);
+double clamp(double v,double lo,double hi);
+double now_sec(void);
+void msleep(int ms);
+#endif


### PR DESCRIPTION
## Summary
- split monolithic `asciiviz.c` into `main.c`, `terminal.c`, and `util.c`
- updated Makefile to build new modules

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c01975fdfc832d918987d1b997fc3a