### PR TITLE
Add Arch PKGBUILD and expanded docs

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,33 @@
+pkgname=asciiviz-git
+_pkgname=asciiviz
+pkgver=0
+pkgrel=1
+pkgdesc="ASCII/ANSI function visualizer with fractal presets and palette support"
+arch=('x86_64')
+url="https://github.com/Szmelc-INC/asciiviz"
+license=('custom')
+depends=('glibc')
+makedepends=('git' 'make' 'gcc')
+provides=('asciiviz')
+conflicts=('asciiviz')
+source=("$_pkgname::git+https://github.com/Szmelc-INC/asciiviz.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_pkgname}"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd "${srcdir}/${_pkgname}"
+  make
+}
+
+package() {
+  cd "${srcdir}/${_pkgname}"
+  install -Dm755 asciiviz "${pkgdir}/usr/bin/asciiviz"
+  install -Dm644 README.md "${pkgdir}/usr/share/doc/${_pkgname}/README.md"
+  install -Dm644 functions/*.cfg "${pkgdir}/usr/share/${_pkgname}/functions/"
+  install -Dm644 palettes/char/*.cfg "${pkgdir}/usr/share/${_pkgname}/palettes/char/"
+  install -Dm644 palettes/col/*.cfg "${pkgdir}/usr/share/${_pkgname}/palettes/col/"
+}

--- a/README.md
+++ b/README.md
@@ -94,45 +94,47 @@
 
 > ### Config Example
 > ```ini
-[render]
-fps=30
-duration=-1          ; -1 = infinite
-use_color=1          ; 1=256-color, 0=mono
-width=0              ; 0 = use terminal width
-height=0             ; 0 = use terminal height
-charset=" .:-=+*#%@" ; ramp for mono
+>[render]
+>fps=30
+>duration=-1          ; -1 = infinite
+>use_color=1          ; 1=256-color, 0=mono
+>width=0              ; 0 = use terminal width
+>height=0             ; 0 = use terminal height
+>charset=" .:-=+*#%@" ; ramp for mono
+>
+>[mode]
+>type=expr            ; expr | mandelbrot | julia
+>
+>[expr]
+>value="sin(6.0*(x+0.2*sin(t*0.7))+t)*cos(6.0*(y+0.2*cos(t*0.5))-t)"
+>color="128+127*sin(t+3.0*r)" ; 0..255 (only used if use_color=1)
+>
+>[fractal]
+>max_iter=200
+>center_x=-0.5
+>center_y=0.0
+>scale=2.8
+>c_re=-0.8             ; julia only
+>c_im=0.156            ; julia only
+>```
 
-[mode]
-type=expr            ; expr | mandelbrot | julia
+> Character palette template:
+> ```ini
+>[char]
+>name="thin"
+>charset=" .:-=+*#%@"
+>```
 
-[expr]
-value="sin(6.0*(x+0.2*sin(t*0.7))+t)*cos(6.0*(y+0.2*cos(t*0.5))-t)"
-color="128+127*sin(t+3.0*r)" ; 0..255 (only used if use_color=1)
-
-[fractal]
-max_iter=200
-center_x=-0.5
-center_y=0.0
-scale=2.8
-c_re=-0.8             ; julia only
-c_im=0.156            ; julia only
-```
-Character palette template:
-```ini
-[char]
-name="thin"
-charset=" .:-=+*#%@"
-```
-Color palette template:
-```ini
-[color]
-name="rainbow_bands"
-codes="21,27,33,39,45,51,50,49,48,47"
-
-[effect]
-# diagonal bands; wrap by palette length (n)
-index="floor(i*0.07 + j*0.07 + t*3.0) mod n"
-```
+> Color palette template:
+> ```ini
+>[color]
+>name="rainbow_bands"
+>codes="21,27,33,39,45,51,50,49,48,47"
+>
+>[effect]
+># diagonal bands; wrap by palette length (n)
+>index="floor(i*0.07 + j*0.07 + t*3.0) mod n"
+>```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,143 @@
-# asciiviz
-ASCII Function Visualizer
+<div align="center">
 
-### Color animation
+<h1><samp><b>asciiviz</b></samp></h1>
 
-Use `--color-func` to drive color palette indices from the currently visualized function rather than the palette's own animation math. While running, press `f` to toggle this behaviour.
+<table><tr><td>ASCII/ANSI function visualizer for your terminal</td></tr></table>
+<i><samp><h4>Render math expressions, Mandelbrot and Julia fractals with colorful palettes</h4></samp></i>
+
+</div>
+
+---
+
+> [!TIP]
+> ## Quick Install
+> Clone
+> ```sh
+> git clone https://github.com/Szmelc-INC/asciiviz.git && cd asciiviz
+> ```
+> Build, install and clean
+> ```sh
+> make && sudo make install && make clean
+> ```
+
+---
+
+> [!NOTE]
+> ## Features
+> - Expression based renderer (`expr` mode)
+> - Mandelbrot and Julia fractals
+> - UTF‑8 character and 256‑color palette system
+> - Baked presets, external `.cfg` files and hot reload (`r` key)
+> - Background fill characters and whitespace transparency
+> - Interactive control: pan, zoom, change palettes and more
+
+---
+
+> [!TIP]
+> ## Usage
+> ```bash
+> asciiviz [--config file] [--preset NAME] [--char NAME] [--color NAME] [--background UTF8] [--color-func]
+> ```
+> ### Flags
+> | Flag | Description |
+> |------|-------------|
+> | `--config <file>` | Load external configuration (`functions/*.cfg`) |
+> | `--preset <name>` | Use baked function preset |
+> | `--char <name>` | Select character palette |
+> | `--color <name>` | Select color palette |
+> | `--background <utf8>` | Override background fill glyph |
+> | `--color-func` | Derive color index from function value |
+>
+> ### Hotkeys
+> | Action | Key(s) |
+> |---|---|
+> | Quit | `q` |
+> | Pause | `p` |
+> | Toggle info HUD | `i` |
+> | Toggle whitespace transparency | `W` |
+> | Cycle background | `w` |
+> | FPS ± | `+` / `-` |
+> | Toggle color | `C` |
+> | Next color palette | `c` |
+> | Toggle color‑math | `f` |
+> | Next char palette | `n` |
+> | Next function preset | `m` |
+> | Reload config | `r` |
+> | Pan | arrow keys |
+> | Zoom | `[` / `]` |
+
+---
+
+> [!IMPORTANT]
+> ## Compiling
+> ```makefile
+> # make                 # build with baked presets & palettes
+> # make run             # run with defaults
+> # sudo make install    # install to /usr/local/bin (override PREFIX/BINDIR)
+> # sudo make uninstall  # remove installed binary
+> # make clean           # clean artifacts
+> ```
+
+---
+
+> [!NOTE]
+> ## Project Structure
+> ```text
+> asciiviz/
+> ├── functions/        # function presets (*.cfg)
+> ├── palettes/         # character and color palettes
+> ├── main.c            # application entry
+> ├── terminal.c/.h     # terminal helpers
+> ├── util.c/.h         # utility functions
+> └── Makefile          # build script
+> ```
+
+> ### Config Example
+> ```ini
+[render]
+fps=30
+duration=-1          ; -1 = infinite
+use_color=1          ; 1=256-color, 0=mono
+width=0              ; 0 = use terminal width
+height=0             ; 0 = use terminal height
+charset=" .:-=+*#%@" ; ramp for mono
+
+[mode]
+type=expr            ; expr | mandelbrot | julia
+
+[expr]
+value="sin(6.0*(x+0.2*sin(t*0.7))+t)*cos(6.0*(y+0.2*cos(t*0.5))-t)"
+color="128+127*sin(t+3.0*r)" ; 0..255 (only used if use_color=1)
+
+[fractal]
+max_iter=200
+center_x=-0.5
+center_y=0.0
+scale=2.8
+c_re=-0.8             ; julia only
+c_im=0.156            ; julia only
+```
+Character palette template:
+```ini
+[char]
+name="thin"
+charset=" .:-=+*#%@"
+```
+Color palette template:
+```ini
+[color]
+name="rainbow_bands"
+codes="21,27,33,39,45,51,50,49,48,47"
+
+[effect]
+# diagonal bands; wrap by palette length (n)
+index="floor(i*0.07 + j*0.07 + t*3.0) mod n"
+```
+
+---
+
+> [!CAUTION]
+> ## Requirements
+> - POSIX like environment (Linux, BSD, macOS)
+> - `gcc`/`clang` and `make`
+> - UTF‑8 capable terminal


### PR DESCRIPTION
## Summary
- add PKGBUILD for Arch-based packaging
- write full README with installation, features, usage flags, hotkeys and config templates

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68c0350e0f38832dad80f80829c509b3