### PR TITLE
Add manual workflows for release and README update

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -1,0 +1,7 @@
+# Manual Workflows
+
+The repository contains a set of manual GitHub Actions workflows.
+Use the links below to open each workflow and trigger it from the UI.
+
+- [Build and Release](../../../actions/workflows/build-release.yml)
+- [Update README](../../../actions/workflows/update-readme.yml)

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,29 @@
+name: Build and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag for the release (e.g., v1.0.0)'
+        required: true
+      release_name:
+        description: 'Release title'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: make
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          name: ${{ github.event.inputs.release_name }}
+          files: |
+            asciiviz

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,26 @@
+name: Update README
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Refresh README timestamp
+        run: |
+          ts=$(date -u '+%Y-%m-%d %H:%M UTC')
+          if grep -q '^Last updated:' README.md; then
+            sed -i "s/^Last updated:.*/Last updated: $ts/" README.md
+          else
+            printf 'Last updated: %s\n\n%s' "$ts" "$(cat README.md)" > README.md
+          fi
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'docs: update README'
+          file_pattern: README.md


### PR DESCRIPTION
## Summary
- add manual build-and-release workflow that compiles and publishes tagged releases
- add manual README updater workflow that refreshes timestamp and commits result
- document available workflows with links to run them manually

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68c03954e2c8832d935a2002844e6014